### PR TITLE
Fix element value check

### DIFF
--- a/Form/DataTransformer/ArrayEntityTransformer.php
+++ b/Form/DataTransformer/ArrayEntityTransformer.php
@@ -80,7 +80,7 @@ class ArrayEntityTransformer implements DataTransformerInterface
                 $value = array_filter($value);
             }
 
-            if (empty($value)) {
+            if (null === $value) {
                 continue;
             }
 


### PR DESCRIPTION
Empty data check for form value should be done by comparing it to null.
Current implementation with empty() check is wrong, because values like "0" are false positive.
For example:
```php
$value = "0";
empty($value); #return true witch obviously is incorrect
(null === $value); #return false witch is correct
```